### PR TITLE
Fix README header rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   <br/>
   <a href="http://bionode.io/">bionode.io</a>
 </p>
+
 # bionode-fasta
 > Streamable FASTA parser.
 


### PR DESCRIPTION
Title wasn't rendering correctly because of no new line.

With changes made:

![image](https://user-images.githubusercontent.com/2754821/29723255-b7776f9e-8978-11e7-9cc8-d80fff985f29.png)
